### PR TITLE
Enable monaco-tailwindcss for css files by default

### DIFF
--- a/examples/demo/src/index.ts
+++ b/examples/demo/src/index.ts
@@ -32,9 +32,46 @@ window.MonacoEnvironment = {
 };
 
 const cssModel = editor.createModel(
-  `body {
-  color: red;
-}`,
+  `@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  h1 {
+    @apply text-2xl;
+  }
+  h2 {
+    @apply text-xl;
+  }
+}
+
+@layer components {
+  .btn-blue {
+    @apply bg-blue-500 hover:bg-blue-700 text-white font-bold font-bold py-2 px-4 rounded;
+  }
+}
+
+@layer utilities {
+  .filter-none {
+    filter: none;
+  }
+  .filter-grayscale {
+    filter: grayscale(100%);
+  }
+}
+
+.select2-dropdown {
+  @apply rounded-b-lg shadow-md;
+}
+
+.select2-search {
+  @apply border border-gray-300 rounded;
+}
+
+.select2-results__group {
+  @apply text-lg font-bold text-gray-900;
+}
+`,
   'css',
 );
 const htmlModel = editor.createModel(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from './languageFeatures';
 import { TailwindcssWorker } from './tailwindcss.worker';
 
-export const defaultLanguageSelector = ['javascript', 'html', 'mdx', 'typescript'] as const;
+export const defaultLanguageSelector = ['css', 'javascript', 'html', 'mdx', 'typescript'] as const;
 
 export const configureMonacoTailwindcss: typeof import('monaco-tailwindcss').configureMonacoTailwindcss =
   ({ config, languageSelector = defaultLanguageSelector } = {}) => {


### PR DESCRIPTION
It’s one of the most useful languages to support.

I also updated the CSS model in the demo with some more representative content.