### PR TITLE
Minor cleanups

### DIFF
--- a/src/getVariants.ts
+++ b/src/getVariants.ts
@@ -1,4 +1,4 @@
-import { AtRule, Container, Node } from 'postcss';
+import { AtRule, Node } from 'postcss';
 
 import { JitState } from './types';
 
@@ -6,7 +6,7 @@ function isAtRule(node: Node): node is AtRule {
   return node.type === 'atrule';
 }
 
-export default function getVariants(state: JitState): Record<string, string | null> {
+export function getVariants(state: JitState): Record<string, string | null> {
   function escape(className: string): string {
     const node = state.modules.postcssSelectorParser.module.className({ value: className });
     return node.value;
@@ -35,10 +35,10 @@ export default function getVariants(state: JitState): Record<string, string | nu
       const returnValue = fn({
         container,
         separator: state.separator,
-        format(def: string) {
+        format(def) {
           definition = def.replace(/:merge\(([^)]+)\)/g, '$1');
         },
-        wrap(rule: Container) {
+        wrap(rule) {
           if (isAtRule(rule)) {
             definition = `@${rule.name} ${rule.params}`;
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,6 @@ export const configureMonacoTailwindcss: typeof import('monaco-tailwindcss').con
         languageSelector,
         createHoverProvider(workerManager.getWorker),
       ),
-      registerMarkerDataProvider(
-        { editor },
-        'html',
-        createMarkerDataProvider(workerManager.getWorker),
-      ),
     ];
 
     // Monaco editor doesn’t provide a function to match language selectors, so let’s just support
@@ -50,10 +45,12 @@ export const configureMonacoTailwindcss: typeof import('monaco-tailwindcss').con
       ? languageSelector
       : [languageSelector]) {
       if (typeof language === 'string') {
-        registerMarkerDataProvider(
-          { editor },
-          language,
-          createMarkerDataProvider(workerManager.getWorker),
+        disposables.push(
+          registerMarkerDataProvider(
+            { editor },
+            language,
+            createMarkerDataProvider(workerManager.getWorker),
+          ),
         );
       }
     }

--- a/src/tailwindcss.worker.ts
+++ b/src/tailwindcss.worker.ts
@@ -4,7 +4,6 @@ import postcss from 'postcss';
 import postcssSelectorParser from 'postcss-selector-parser';
 import {
   AugmentedDiagnostic,
-  // CompletionsFromClassList,
   doComplete,
   doHover,
   doValidate,
@@ -27,12 +26,8 @@ import {
   Position,
 } from 'vscode-languageserver-types';
 
-import getVariants from './getVariants.js';
+import { getVariants } from './getVariants.js';
 import { JitState } from './types';
-
-function isObject(value: unknown): value is object {
-  return typeof value === 'object' && value != null;
-}
 
 export interface TailwindcssWorker {
   doComplete: (
@@ -56,10 +51,6 @@ initialize<TailwindcssWorker, MonacoTailwindcssOptions>((ctx, options) => {
     options.tailwindConfig ?? ({} as Partial<TailwindConfig> as TailwindConfig),
   );
 
-  // Const lspRoot = await postcss([
-  //   tailwindcss({ ...config, mode: 'aot', purge: false, variants: [] }),
-  // ]).process();
-
   const jitContext = createContext(config);
 
   const state: JitState = {
@@ -79,12 +70,10 @@ initialize<TailwindcssWorker, MonacoTailwindcssOptions>((ctx, options) => {
       classNames: {},
       context: {},
     },
-    // ClassNames: extractClasses(lspRoot),
-
     jit: true,
     jitContext,
     separator: ':',
-    screens: isObject(config.theme.screens) ? Object.keys(config.theme.screens) : [],
+    screens: config.theme.screens ? Object.keys(config.theme.screens) : [],
     editor: {
       userLanguages: {},
       // @ts-expect-error this is poorly typed

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,6 @@ import { createContext, JitContext } from 'tailwindcss/src/lib/setupContextUtils
 export interface JitState extends State {
   config: object;
   separator: string;
-  screens: string[];
-  variants: Record<string, string | null>;
-  jit: true;
   jitContext: JitContext;
   modules: {
     postcss: {


### PR DESCRIPTION
- Remove some commented code
- Remove some redundant code
- Remove some redundant type definitions
- Remove duplicate registration of html diagnostics provider
- Avoid default exports