### PR TITLE
Move @types/tailwindcss into dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "@ctrl/tinycolor": "^3.0.0",
+        "@types/tailwindcss": "^3.0.0",
         "color-name": "^1.0.0",
         "css.escape": "^1.0.0",
         "dlv": "^1.0.0",
@@ -32,7 +33,6 @@
         "vscode-languageserver-textdocument": "^1.0.0"
       },
       "devDependencies": {
-        "@types/tailwindcss": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "eslint": "^8.0.0",
         "eslint-config-remcohaszing": "^3.0.0",
@@ -503,8 +503,7 @@
     "node_modules/@types/tailwindcss": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/tailwindcss/-/tailwindcss-3.0.10.tgz",
-      "integrity": "sha512-1UnZIHO0NOPyPlPFV0HuMjki2SHkvG9uBA1ZehWj/OQMSROk503nuNyyfmJSIT289yewxTbKoPG+KLxYRvfIIg==",
-      "dev": true
+      "integrity": "sha512-1UnZIHO0NOPyPlPFV0HuMjki2SHkvG9uBA1ZehWj/OQMSROk503nuNyyfmJSIT289yewxTbKoPG+KLxYRvfIIg=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://monaco-tailwindcss.js.org",
   "dependencies": {
     "@ctrl/tinycolor": "^3.0.0",
+    "@types/tailwindcss": "^3.0.0",
     "color-name": "^1.0.0",
     "css.escape": "^1.0.0",
     "dlv": "^1.0.0",
@@ -56,7 +57,6 @@
     "monaco-editor": ">=0.30"
   },
   "devDependencies": {
-    "@types/tailwindcss": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "eslint": "^8.0.0",
     "eslint-config-remcohaszing": "^3.0.0",


### PR DESCRIPTION
Our type definitions depend on it, meaning our users depend on it.