### PR TITLE
Fix support for a custom separator

### DIFF
--- a/src/getVariants.ts
+++ b/src/getVariants.ts
@@ -34,7 +34,7 @@ export function getVariants(state: JitState): Record<string, string | null> {
       const container = root.clone();
       const returnValue = fn({
         container,
-        separator: state.separator,
+        separator: state.separator!,
         format(def) {
           definition = def.replace(/:merge\(([^)]+)\)/g, '$1');
         },

--- a/src/tailwindcss.worker.ts
+++ b/src/tailwindcss.worker.ts
@@ -69,7 +69,7 @@ function stateFromConfig(config: TailwindConfig): JitState {
     },
     jit: true,
     jitContext,
-    separator: ':',
+    separator: config.separator,
     screens: config.theme.screens ? Object.keys(config.theme.screens) : [],
     editor: {
       userLanguages: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ import { createContext, JitContext } from 'tailwindcss/src/lib/setupContextUtils
 
 export interface JitState extends State {
   config: object;
-  separator: string;
   jitContext: JitContext;
   modules: {
     postcss: {


### PR DESCRIPTION
Users may specify `separator` in their Tailwind config.