### PR TITLE
Use imports instead of state.modules

### DIFF
--- a/src/getVariants.ts
+++ b/src/getVariants.ts
@@ -1,4 +1,5 @@
-import { AtRule, Node } from 'postcss';
+import postcss, { AtRule, Node } from 'postcss';
+import postcssSelectorParser from 'postcss-selector-parser';
 
 import { JitState } from './types';
 
@@ -6,21 +7,21 @@ function isAtRule(node: Node): node is AtRule {
   return node.type === 'atrule';
 }
 
-export function getVariants(state: JitState): Record<string, string | null> {
-  function escape(className: string): string {
-    const node = state.modules.postcssSelectorParser.module.className({ value: className });
-    return node.value;
-  }
+function escape(className: string): string {
+  const node = postcssSelectorParser.className({ value: className });
+  return node.value;
+}
 
+export function getVariants(state: JitState): Record<string, string | null> {
   const result: Record<string, string | null> = {};
   for (const [variantName, variantIdsAndFns] of state.jitContext.variantMap) {
     const fns = variantIdsAndFns.map(([, fn]) => fn);
 
     const placeholder = '__variant_placeholder__';
 
-    const root = state.modules.postcss.module.root({
+    const root = postcss.root({
       nodes: [
-        state.modules.postcss.module.rule({
+        postcss.rule({
           selector: `.${escape(placeholder)}`,
           nodes: [],
         }),

--- a/src/getVariants.ts
+++ b/src/getVariants.ts
@@ -1,7 +1,6 @@
 import postcss, { AtRule, Node } from 'postcss';
 import postcssSelectorParser from 'postcss-selector-parser';
-
-import { JitState } from './types';
+import { JitContext } from 'tailwindcss/src/lib/setupContextUtils.js';
 
 function isAtRule(node: Node): node is AtRule {
   return node.type === 'atrule';
@@ -12,9 +11,9 @@ function escape(className: string): string {
   return node.value;
 }
 
-export function getVariants(state: JitState): Record<string, string | null> {
+export function getVariants(jitContext: JitContext): Record<string, string | null> {
   const result: Record<string, string | null> = {};
-  for (const [variantName, variantIdsAndFns] of state.jitContext.variantMap) {
+  for (const [variantName, variantIdsAndFns] of jitContext.variantMap) {
     const placeholder = '__variant_placeholder__';
 
     const root = postcss.root({
@@ -33,7 +32,7 @@ export function getVariants(state: JitState): Record<string, string | null> {
       const container = root.clone();
       const returnValue = fn({
         container,
-        separator: state.separator!,
+        separator: jitContext.tailwindConfig.separator!,
         format(def) {
           definition = def.replace(/:merge\(([^)]+)\)/g, '$1');
         },

--- a/src/tailwindcss.worker.ts
+++ b/src/tailwindcss.worker.ts
@@ -71,6 +71,7 @@ function stateFromConfig(config: TailwindConfig): JitState {
     jitContext,
     separator: config.separator,
     screens: config.theme.screens ? Object.keys(config.theme.screens) : [],
+    variants: getVariants(jitContext),
     editor: {
       userLanguages: {},
       // @ts-expect-error this is poorly typed
@@ -95,8 +96,6 @@ function stateFromConfig(config: TailwindConfig): JitState {
       },
     },
   };
-
-  state.variants = getVariants(state);
 
   state.classList = jitContext
     .getClassList()

--- a/types.d.ts
+++ b/types.d.ts
@@ -29,6 +29,7 @@ declare module 'tailwindcss/src/lib/setupContextUtils.js' {
 
   export interface JitContext {
     getClassList: () => string[];
+    tailwindConfig: TailwindConfig;
     variantMap: Map<VariantName, VariantFn[]>;
   }
 


### PR DESCRIPTION
We always specify this. It looks a bit cleaner to use regular imports to access these modules.