### PR TITLE
Allow async config processing and a string config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export interface MonacoTailwindcssOptions {
    */
   languageSelector?: languages.LanguageSelector;
 
-  tailwindConfig?: TailwindConfig;
+  tailwindConfig?: TailwindConfig | string;
 }
 
 export interface MonacoTailwindcss extends IDisposable {

--- a/tailwindcss.worker.d.ts
+++ b/tailwindcss.worker.d.ts
@@ -4,7 +4,9 @@ export interface TailwindWorkerOptions {
   /**
    * Hook that will run before the tailwind config is used.
    */
-  prepareTailwindConfig?: (tailwindConfig?: TailwindConfig) => TailwindConfig;
+  prepareTailwindConfig?: (
+    tailwindConfig?: TailwindConfig | string,
+  ) => PromiseLike<TailwindConfig> | TailwindConfig;
 }
 
 export function initialize(tailwindWorkerOptions?: TailwindWorkerOptions): void;


### PR DESCRIPTION
If a Tailwind config is a string, it’s up to a custom worker implementation to convert it into an object.

Closes #43