### PR TITLE
Fix overflow issues on fixed color decorations

### DIFF
--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -418,7 +418,11 @@ export function createColorProvider(
           nonEditableColors.map(({ color, range }) => ({
             range,
             options: {
-              beforeContentClassName: `colorpicker-color-decoration ${createColorClass(color)}`,
+              before: {
+                content: '\u00A0',
+                inlineClassName: `${createColorClass(color)} colorpicker-color-decoration`,
+                inlineClassNameAffectsLetterSpacing: true,
+              },
             },
           })),
         ),


### PR DESCRIPTION
This now uses the same decoration options as builtin Monaco color decorations.

https://github.com/microsoft/vscode/blob/1.70.2/src/vs/editor/contrib/colorPicker/browser/colorDetector.ts#L211-L213