### PR TITLE
Allow passing a string to setTailwindConfig

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ export interface MonacoTailwindcss extends IDisposable {
    *
    * @param tailwindConfig - The new Tailwind configuration.
    */
-  setTailwindConfig: (tailwindConfig: Config) => void;
+  setTailwindConfig: (tailwindConfig: Config | string) => void;
 
   /**
    * Generate styles using Tailwindcss.


### PR DESCRIPTION
This matches the type of the initial configuration and the type of the worker.