### PR TITLE
Use monaco-languageserver-types

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -16,7 +16,7 @@
     "html-webpack-plugin": "^5.0.0",
     "jsonc-parser": "^3.0.0",
     "mini-css-extract-plugin": "^2.0.0",
-    "monaco-editor": "^0.34.0",
+    "monaco-editor": "^0.36.0",
     "monaco-tailwindcss": "file:../..",
     "ts-loader": "^9.0.0",
     "typescript": "^4.0.0",

--- a/examples/esbuild-demo/package.json
+++ b/examples/esbuild-demo/package.json
@@ -7,7 +7,7 @@
     "start": "rm -rf ./dist && node build.js"
   },
   "dependencies": {
-    "monaco-editor": "^0.34.0",
+    "monaco-editor": "^0.36.0",
     "monaco-tailwindcss": "file:../..",
     "esbuild": "^0.15.0"
   }

--- a/examples/vite-example/package.json
+++ b/examples/vite-example/package.json
@@ -8,7 +8,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "monaco-editor": "^0.34.0",
+    "monaco-editor": "^0.36.0",
     "monaco-tailwindcss": "file:../..",
     "vite": "^3.0.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "didyoumean": "^1.0.0",
         "dlv": "^1.0.0",
         "line-column": "^1.0.0",
+        "monaco-languageserver-types": "^0.2.0",
         "monaco-marker-data-provider": "^1.0.0",
         "monaco-worker-manager": "^2.0.0",
         "moo": "^0.5.0",
@@ -49,7 +50,7 @@
         "url": "https://github.com/sponsors/remcohaszing"
       },
       "peerDependencies": {
-        "monaco-editor": ">=0.30"
+        "monaco-editor": ">=0.36"
       }
     },
     "examples/demo": {
@@ -63,7 +64,7 @@
         "html-webpack-plugin": "^5.0.0",
         "jsonc-parser": "^3.0.0",
         "mini-css-extract-plugin": "^2.0.0",
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "^0.36.0",
         "monaco-tailwindcss": "file:../..",
         "ts-loader": "^9.0.0",
         "typescript": "^4.0.0",
@@ -76,14 +77,14 @@
       "version": "1.0.0",
       "dependencies": {
         "esbuild": "^0.15.0",
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "^0.36.0",
         "monaco-tailwindcss": "file:../.."
       }
     },
     "examples/vite-example": {
       "version": "1.0.0",
       "dependencies": {
-        "monaco-editor": "^0.34.0",
+        "monaco-editor": "^0.36.0",
         "monaco-tailwindcss": "file:../..",
         "vite": "^3.0.0"
       }
@@ -5092,9 +5093,21 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
-      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ=="
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.36.1.tgz",
+      "integrity": "sha512-/CaclMHKQ3A6rnzBzOADfwdSJ25BFoFT0Emxsc4zYVyav5SkK9iA6lEtIeuN/oRYbwPgviJT+t3l+sjFa28jYg=="
+    },
+    "node_modules/monaco-languageserver-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.2.0.tgz",
+      "integrity": "sha512-FC1N8ulNAfWkyrZsTQpSW3xqetWmhyBhB8eWlfxExelBCmYvSiwYYzNMn+UmPVjXLABQM0Odfw6k1ncDfkTbDQ==",
+      "dependencies": {
+        "monaco-types": "^0.1.0",
+        "vscode-languageserver-protocol": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
     },
     "node_modules/monaco-marker-data-provider": {
       "version": "1.1.1",
@@ -5110,6 +5123,14 @@
     "node_modules/monaco-tailwindcss": {
       "resolved": "",
       "link": true
+    },
+    "node_modules/monaco-types": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/monaco-types/-/monaco-types-0.1.0.tgz",
+      "integrity": "sha512-aWK7SN9hAqNYi0WosPoMjenMeXJjwCxDibOqWffyQ/qXdzB/86xshGQobRferfmNz7BSNQ8GB0MD0oby9/5fTQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      }
     },
     "node_modules/monaco-worker-manager": {
       "version": "2.0.1",
@@ -7886,7 +7907,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
       "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
-      "dev": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7907,7 +7927,6 @@
       "version": "3.17.2",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
       "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
-      "dev": true,
       "dependencies": {
         "vscode-jsonrpc": "8.0.2",
         "vscode-languageserver-types": "3.17.2"
@@ -7921,8 +7940,7 @@
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.2",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==",
-      "dev": true
+      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.0.0",
     "color-name": "^1.0.0",
     "css.escape": "^1.0.0",
-    "dlv": "^1.0.0",
     "didyoumean": "^1.0.0",
+    "dlv": "^1.0.0",
     "line-column": "^1.0.0",
+    "monaco-languageserver-types": "^0.2.0",
     "monaco-marker-data-provider": "^1.0.0",
     "monaco-worker-manager": "^2.0.0",
     "moo": "^0.5.0",
@@ -60,7 +61,7 @@
     "vscode-languageserver-textdocument": "^1.0.0"
   },
   "peerDependencies": {
-    "monaco-editor": ">=0.30"
+    "monaco-editor": ">=0.36"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { setMonaco } from 'monaco-languageserver-types';
 import { registerMarkerDataProvider } from 'monaco-marker-data-provider';
 import { MonacoTailwindcssOptions } from 'monaco-tailwindcss';
 import { createWorkerManager } from 'monaco-worker-manager';
@@ -16,6 +17,8 @@ export { tailwindcssData } from './cssData.js';
 
 export const configureMonacoTailwindcss: typeof import('monaco-tailwindcss').configureMonacoTailwindcss =
   (monaco, { tailwindConfig, languageSelector = defaultLanguageSelector } = {}) => {
+    setMonaco(monaco);
+
     const workerManager = createWorkerManager<TailwindcssWorker, MonacoTailwindcssOptions>(monaco, {
       label: 'tailwindcss',
       moduleId: 'monaco-tailwindcss/tailwindcss.worker',
@@ -48,7 +51,7 @@ export const configureMonacoTailwindcss: typeof import('monaco-tailwindcss').con
           registerMarkerDataProvider(
             monaco,
             language,
-            createMarkerDataProvider(monaco, workerManager.getWorker),
+            createMarkerDataProvider(workerManager.getWorker),
           ),
         );
       }

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -1,360 +1,23 @@
 import { fromRatio, names as namedColors } from '@ctrl/tinycolor';
 // We use a type import here as a safe guard to prevent monaco-editor imports in the output bundle
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import type { editor, IPosition, IRange, languages, MarkerSeverity } from 'monaco-editor';
+import type { editor, languages } from 'monaco-editor';
+import {
+  fromCompletionContext,
+  fromCompletionItem,
+  fromPosition,
+  toColorInformation,
+  toCompletionItem,
+  toCompletionList,
+  toHover,
+  toMarkerData,
+} from 'monaco-languageserver-types';
 import { MarkerDataProvider } from 'monaco-marker-data-provider';
 import { WorkerGetter } from 'monaco-worker-manager';
-import { AugmentedDiagnostic } from 'tailwindcss-language-service';
-import { CompletionContext, CompletionTriggerKind } from 'vscode-languageserver-protocol';
-import * as ls from 'vscode-languageserver-types';
 
 import { TailwindcssWorker } from './tailwindcss.worker.js';
 
 type WorkerAccessor = WorkerGetter<TailwindcssWorker>;
-
-function lsRangeToMonacoRange(range: ls.Range): IRange {
-  return {
-    startLineNumber: range.start.line + 1,
-    startColumn: range.start.character + 1,
-    endLineNumber: range.end.line + 1,
-    endColumn: range.end.character + 1,
-  };
-}
-
-function lsColorInformationToMonacoColorInformation(
-  color: ls.ColorInformation,
-): languages.IColorInformation {
-  return {
-    color: color.color,
-    range: lsRangeToMonacoRange(color.range),
-  };
-}
-
-function lsHoverToMonacoHover(hover: ls.Hover): languages.Hover {
-  const contents = [hover.contents].flat();
-
-  return {
-    contents: contents.map((content) => ({
-      value:
-        typeof content === 'string'
-          ? content
-          : 'language' in content
-          ? `\`\`\`${content.language}\n${content.value}\n\`\`\``
-          : content.value,
-    })),
-    range: hover.range ? lsRangeToMonacoRange(hover.range) : undefined,
-  };
-}
-
-function monacoPositionToLsPosition(position: IPosition): ls.Position {
-  return {
-    line: position.lineNumber - 1,
-    character: position.column - 1,
-  };
-}
-
-function monacoCompletionTriggerKindToLsCompletionTriggerKind(
-  completionTriggerKind: languages.CompletionTriggerKind,
-): CompletionTriggerKind {
-  switch (completionTriggerKind) {
-    // Invoke
-    case 0:
-      return 1;
-    // TriggerCharacter
-    case 1:
-      return 2;
-    // TriggerForIncompleteCompletions
-    default:
-      return 3;
-  }
-}
-
-function lsCompletionItemKindToMonacoCompletionItemKind(
-  completionItemKind: ls.CompletionItemKind,
-): languages.CompletionItemKind {
-  switch (completionItemKind) {
-    // Text
-    case 1:
-      return 18;
-    // Method
-    case 2:
-      return 0;
-    // Function
-    case 3:
-      return 1;
-    // Constructor
-    case 4:
-      return 2;
-    // Field
-    case 5:
-      return 3;
-    // Variable
-    case 6:
-      return 4;
-    // Class
-    case 7:
-      return 5;
-    // Interface
-    case 8:
-      return 7;
-    // Module
-    case 9:
-      return 8;
-    // Property
-    case 10:
-      return 9;
-    // Unit
-    case 11:
-      return 12;
-    // Value
-    case 12:
-      return 13;
-    // Enum
-    case 13:
-      return 15;
-    // Keyword
-    case 14:
-      return 17;
-    // Snippet
-    case 15:
-      return 27;
-    // Color
-    case 16:
-      return 19;
-    // File
-    case 17:
-      return 20;
-    // Reference
-    case 18:
-      return 21;
-    // Folder
-    case 19:
-      return 23;
-    // EnumMember
-    case 20:
-      return 16;
-    // Constant
-    case 21:
-      return 14;
-    // Struct
-    case 22:
-      return 6;
-    // Event
-    case 23:
-      return 10;
-    // Operator
-    case 24:
-      return 11;
-    // TypeParameter
-    default:
-      return 24;
-  }
-}
-
-function monacoCompletionItemKindToLsCompletionItemKind(
-  completionItemKind: languages.CompletionItemKind,
-): ls.CompletionItemKind {
-  switch (completionItemKind) {
-    // Text
-    case 18:
-      return 1;
-    // Method
-    case 0:
-      return 2;
-    // Function
-    case 1:
-      return 3;
-    // Constructor
-    case 2:
-      return 4;
-    // Field
-    case 3:
-      return 5;
-    // Variable
-    case 4:
-      return 6;
-    // Class
-    case 5:
-      return 7;
-    // Interface
-    case 7:
-      return 8;
-    // Module
-    case 8:
-      return 9;
-    // Property
-    case 9:
-      return 10;
-    // Unit
-    case 12:
-      return 11;
-    // Value
-    case 13:
-      return 12;
-    // Enum
-    case 15:
-      return 13;
-    // Keyword
-    case 17:
-      return 14;
-    // Snippet
-    case 27:
-      return 15;
-    // Color
-    case 19:
-      return 16;
-    // File
-    case 20:
-      return 17;
-    // Reference
-    case 21:
-      return 18;
-    // Folder
-    case 23:
-      return 19;
-    // EnumMember
-    case 16:
-      return 20;
-    // Constant
-    case 14:
-      return 21;
-    // Struct
-    case 6:
-      return 22;
-    // Event
-    case 10:
-      return 23;
-    // Operator
-    case 11:
-      return 24;
-    // TypeParameter
-    default:
-      return 25;
-  }
-}
-
-function monacoCompletionContextToLsCompletionContext(
-  completionContext: languages.CompletionContext,
-): CompletionContext {
-  return {
-    triggerKind: monacoCompletionTriggerKindToLsCompletionTriggerKind(
-      completionContext.triggerKind,
-    ),
-    triggerCharacter: completionContext.triggerCharacter,
-  };
-}
-
-function lsCommandToMonacoCommand(command: ls.Command): languages.Command {
-  return {
-    title: command.title,
-    id: command.command,
-    arguments: command.arguments,
-  };
-}
-
-function lsCompletionItemToMonacoCompletionItem(
-  completionItem: ls.CompletionItem,
-): languages.CompletionItem {
-  return {
-    label: completionItem.label,
-    kind: lsCompletionItemKindToMonacoCompletionItemKind(completionItem.kind!),
-    tags: completionItem.tags,
-    detail: completionItem.detail,
-    documentation:
-      completionItem.documentation && typeof completionItem.documentation === 'object'
-        ? { value: completionItem.documentation.value }
-        : completionItem.documentation,
-    sortText: completionItem.sortText,
-    filterText: completionItem.filterText,
-    preselect: completionItem.preselect,
-    insertText: completionItem.insertText ?? completionItem.label,
-    // @ts-expect-error XXX we need a fallback range here.
-    range:
-      completionItem.textEdit &&
-      lsRangeToMonacoRange(
-        'range' in completionItem.textEdit
-          ? completionItem.textEdit.range
-          : completionItem.textEdit.replace,
-      ),
-    command: completionItem.command && lsCommandToMonacoCommand(completionItem.command),
-    commitCharacters: completionItem.commitCharacters,
-  };
-}
-
-function monacoCompletionItemToLsCompletionItem(
-  completionItem: languages.CompletionItem,
-): ls.CompletionItem {
-  return {
-    label:
-      typeof completionItem.label === 'string' ? completionItem.label : completionItem.label.label,
-    data: [completionItem.label],
-    kind: monacoCompletionItemKindToLsCompletionItemKind(completionItem.kind),
-    tags: completionItem.tags as undefined,
-    detail: completionItem.detail,
-    documentation:
-      completionItem.documentation && typeof completionItem.documentation === 'object'
-        ? { value: completionItem.documentation.value, kind: 'markdown' }
-        : completionItem.documentation,
-    sortText: completionItem.sortText,
-    filterText: completionItem.filterText,
-    preselect: completionItem.preselect,
-    insertText: completionItem.insertText,
-  };
-}
-
-function lsCompletionListToMonacoCompletionList(
-  completionList: ls.CompletionList,
-): languages.CompletionList {
-  return {
-    incomplete: completionList.isIncomplete,
-    suggestions: completionList.items.map(lsCompletionItemToMonacoCompletionItem),
-  };
-}
-
-function lsDiagnosticSeverityToMonacoModelMarkerSeverity(
-  severity: ls.DiagnosticSeverity | undefined,
-): MarkerSeverity {
-  switch (severity) {
-    // Warning
-    case 2:
-      return 4;
-    // Information
-    case 3:
-      return 2;
-    // Hint
-    case 4:
-      return 1;
-    // Error
-    default:
-      return 8;
-  }
-}
-
-function lsDiagnosticRelatedInformationToMonacoRelatedInformation(
-  relatedInformation: ls.DiagnosticRelatedInformation,
-  monaco: typeof import('monaco-editor'),
-): editor.IRelatedInformation {
-  return {
-    ...lsRangeToMonacoRange(relatedInformation.location.range),
-    resource: monaco.Uri.parse(relatedInformation.location.uri),
-    message: relatedInformation.message,
-  };
-}
-
-function augmentedDiagnosticToMonacoModelMarker(
-  diagnostic: AugmentedDiagnostic,
-  monaco: typeof import('monaco-editor'),
-): editor.IMarkerData {
-  return {
-    ...lsRangeToMonacoRange(diagnostic.range),
-    message: diagnostic.message,
-    severity: lsDiagnosticSeverityToMonacoModelMarkerSeverity(diagnostic.severity),
-    code: diagnostic.code,
-    relatedInformation: diagnostic.relatedInformation?.map((relatedInformation) =>
-      lsDiagnosticRelatedInformationToMonacoRelatedInformation(relatedInformation, monaco),
-    ),
-  };
-}
 
 const colorNames = Object.values(namedColors);
 const editableColorRegex = new RegExp(
@@ -402,7 +65,7 @@ export function createColorProvider(
       const nonEditableColors: languages.IColorInformation[] = [];
       const colors = await worker.getDocumentColors(String(model.uri), model.getLanguageId());
       for (const lsColor of colors) {
-        const monacoColor = lsColorInformationToMonacoColorInformation(lsColor);
+        const monacoColor = toColorInformation(lsColor);
         const text = model.getValueInRange(monacoColor.range);
         if (editableColorRegex.test(text)) {
           editableColors.push(monacoColor);
@@ -482,10 +145,10 @@ export function createHoverProvider(getWorker: WorkerAccessor): languages.HoverP
       const hover = await worker.doHover(
         String(model.uri),
         model.getLanguageId(),
-        monacoPositionToLsPosition(position),
+        fromPosition(position),
       );
 
-      return hover && lsHoverToMonacoHover(hover);
+      return hover && toHover(hover);
     },
   };
 }
@@ -500,29 +163,37 @@ export function createCompletionItemProvider(
       const completionList = await worker.doComplete(
         String(model.uri),
         model.getLanguageId(),
-        monacoPositionToLsPosition(position),
-        monacoCompletionContextToLsCompletionContext(context),
+        fromPosition(position),
+        fromCompletionContext(context),
       );
 
-      return completionList && lsCompletionListToMonacoCompletionList(completionList);
+      if (!completionList) {
+        return;
+      }
+
+      const wordInfo = model.getWordUntilPosition(position);
+
+      return toCompletionList(completionList, {
+        range: {
+          startLineNumber: position.lineNumber,
+          startColumn: wordInfo.startColumn,
+          endLineNumber: position.lineNumber,
+          endColumn: wordInfo.endColumn,
+        },
+      });
     },
 
     async resolveCompletionItem(item) {
       const worker = await getWorker();
 
-      const result = await worker.resolveCompletionItem(
-        monacoCompletionItemToLsCompletionItem(item),
-      );
+      const result = await worker.resolveCompletionItem(fromCompletionItem(item));
 
-      return lsCompletionItemToMonacoCompletionItem(result);
+      return toCompletionItem(result, { range: item.range });
     },
   };
 }
 
-export function createMarkerDataProvider(
-  monaco: typeof import('monaco-editor'),
-  getWorker: WorkerAccessor,
-): MarkerDataProvider {
+export function createMarkerDataProvider(getWorker: WorkerAccessor): MarkerDataProvider {
   return {
     owner: 'tailwindcss',
     async provideMarkerData(model) {
@@ -530,9 +201,7 @@ export function createMarkerDataProvider(
 
       const diagnostics = await worker.doValidate(String(model.uri), model.getLanguageId());
 
-      return diagnostics.map((diagnostic) =>
-        augmentedDiagnosticToMonacoModelMarker(diagnostic, monaco),
-      );
+      return diagnostics.map((diagnostic) => toMarkerData(diagnostic));
     },
   };
 }


### PR DESCRIPTION
This package contains logic for converting between Monaco and language server types. It’s also well tested. Its logic is mostlt extracted from `monaco-tailwindcss` and `monaco-yaml`.

This raises the minimum required Monaco editor version to 0.36.