### PR TITLE
PR [Feature]: Use Tailwind's built-in Plugin API and configure Intellisense.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,8 +108,8 @@ export interface MonacoTailwindcssOptions {
         addUtilities({
           '.custom-class': {
             color: '#000000',
-            'font-size': '1rem',
-            'font-weight': 900
+            fontSize: '1rem',
+            fontWeight: 900
           }
         })
       }
@@ -130,8 +130,8 @@ export interface MonacoTailwindcssOptions {
  *      {
  *        '.custom-class': {
  *          color: '#000000',
- *          'font-size': '1rem',
- *          'font-weight': 900
+ *          fontSize: '1rem',
+ *          fontWeight: 900
  *        }
  *      }
  *    ]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,21 @@
+import { EditorSettings, TailwindCssSettings } from '@tailwindcss/language-service'
 import { type IDisposable, type languages, type MonacoEditor } from 'monaco-types'
 import { type Config } from 'tailwindcss'
+import { PluginAPI } from 'tailwindcss/types/config.js'
 
 /**
- * A Tailwind configuration, but without content.
+ * A Tailwind configuration, where all properties are optional.
  */
-export type TailwindConfig = Omit<Config, 'content'>
+export type TailwindConfig = Partial<Config>
+
+/**
+ * An object of the arguments for the Tailwind's built-in Plugin API.
+ */
+export type TailwindPluginAPI = Partial<{
+  [T in keyof PluginAPI]: Parameters<PluginAPI[T]>
+}>
+
+type DiagnosticSeveritySetting = 'ignore' | 'warning' | 'error'
 
 export interface MonacoTailwindcssOptions {
   /**
@@ -19,6 +30,114 @@ export interface MonacoTailwindcssOptions {
    * worker.
    */
   tailwindConfig?: TailwindConfig | string
+  /**
+   * Extend Intellisense's settings.
+   * 
+   * Default values are based on the VS Code extension.
+   * 
+   * ``` typescript
+   * const defaultSettings = {
+      editor: {tabSize: 2},
+      tailwindCSS: {
+        emmetCompletions: false,
+        classAttributes: ["class", "className", "ngClass"],
+        codeActions: true,
+        hovers: true,
+        suggestions: true,
+        validate: true,
+        colorDecorators: true,
+        rootFontSize: 16,
+        showPixelEquivalents: true,
+        includeLanguages: {},
+        files: {exclude: []},
+        experimental: {
+          classRegex: [],
+          configFile: {}
+        },
+        lint: {
+          cssConflict: "warning",
+          invalidApply: "error",
+          invalidScreen: "error",
+          invalidVariant: "error",
+          invalidConfigPath: "error",
+          invalidTailwindDirective: "error",
+          recommendedVariantOrder: "warning"
+        },
+      }
+    }
+   */
+  intellisense?: Partial<{
+    editor: {
+      tabSize: number
+    }
+    tailwindCSS: Partial<{
+      emmetCompletions: boolean
+      includeLanguages: Record<string, string>
+      classAttributes: string[]
+      suggestions: boolean
+      hovers: boolean
+      codeActions: boolean
+      validate: boolean
+      showPixelEquivalents: boolean
+      rootFontSize: number
+      colorDecorators: boolean
+      files: { exclude: string[] }
+      experimental: {
+        classRegex: string[]
+        configFile: string | Record<string, string | string[]>
+      }
+      lint: {
+        cssConflict: DiagnosticSeveritySetting
+        invalidApply: DiagnosticSeveritySetting
+        invalidScreen: DiagnosticSeveritySetting
+        invalidVariant: DiagnosticSeveritySetting
+        invalidConfigPath: DiagnosticSeveritySetting
+        invalidTailwindDirective: DiagnosticSeveritySetting
+        recommendedVariantOrder: DiagnosticSeveritySetting
+      }
+    }>
+  }>
+  /**
+ * A way to call Tailwind's built-in Plugin API within the worker.
+ * ``` typescript
+ * 
+   // Instead of calling the functions like this...
+ * const tailwindConfig = {
+ *  // ...config
+ *  plugins: [
+      ({addUtilities}) => {
+        addUtilities({
+          '.custom-class': {
+            color: '#000000',
+            'font-size': '1rem',
+            'font-weight': 900
+          }
+        })
+      }
+    ]
+ * }
+
+// ...you provide an array of the parameters for each function you want to call.
+// Note that the arguments you pass must be serializable,
+// e.g they can't include functions.
+
+ * const tailwindConfig = {
+ *  // ...config
+ *  pluginAPI: {
+ *    addUtilities: [
+ *      {
+ *        '.custom-class': {
+ *          color: '#000000',
+ *          'font-size': '1rem',
+ *          'font-weight': 900
+ *        }
+ *      }
+ *    ]
+ *  }
+ * }
+ * ```
+ */
+  pluginAPI?: TailwindPluginAPI
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import { EditorSettings, TailwindCssSettings } from '@tailwindcss/language-service'
 import { type IDisposable, type languages, type MonacoEditor } from 'monaco-types'
 import { type Config } from 'tailwindcss'
 import { PluginAPI } from 'tailwindcss/types/config.js'
@@ -103,7 +102,7 @@ export interface MonacoTailwindcssOptions {
  * 
    // Instead of calling the functions like this...
  * const tailwindConfig = {
- *  // ...config
+   // ...config
  *  plugins: [
       ({addUtilities}) => {
         addUtilities({
@@ -122,7 +121,7 @@ export interface MonacoTailwindcssOptions {
 // e.g they can't include functions.
 
  * const tailwindConfig = {
- *  // ...config
+   // ...config
  *  pluginAPI: {
  *    addUtilities: [
  *      {

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ export interface MonacoTailwindcssOptions {
  * A way to call Tailwind's built-in Plugin API within the worker.
  * ``` typescript
  * 
-   // Instead of calling the functions like this...
+   // Instead of calling the functions inside your config like this...
  * const tailwindConfig = {
    // ...config
  *  plugins: [
@@ -116,12 +116,15 @@ export interface MonacoTailwindcssOptions {
     ]
  * }
 
-// ...you provide an array of the parameters for each function you want to call.
+// ...you provide an array containing the arguments
+// for each function you wish to call.
+
 // Note that the arguments you pass must be serializable,
 // e.g they can't include functions.
 
- * const tailwindConfig = {
-   // ...config
+ * const options = {
+    tailwindConfig: {...},
+    intellisense: {...},
  *  pluginAPI: {
  *    addUtilities: [
  *      {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "monaco-tailwindcss",
-  "version": "0.6.1",
+  "name": "monaco-tailwind",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "monaco-tailwindcss",
-      "version": "0.6.1",
+      "name": "monaco-tailwind",
+      "version": "0.0.1",
       "license": "MIT",
       "workspaces": [
         "examples/*"
@@ -25,6 +25,7 @@
         "line-column": "^1.0.0",
         "monaco-languageserver-types": "^0.4.0",
         "monaco-marker-data-provider": "^1.0.0",
+        "monaco-tailwind": "^0.0.1",
         "monaco-types": "^0.1.0",
         "monaco-worker-manager": "^2.0.0",
         "moo": "^0.5.0",
@@ -9137,6 +9138,50 @@
       },
       "peerDependencies": {
         "monaco-editor": ">=0.30.0"
+      }
+    },
+    "node_modules/monaco-tailwind": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/monaco-tailwind/-/monaco-tailwind-0.0.1.tgz",
+      "integrity": "sha512-Ejb8nlCATS3tEw2QDQFoNDO4uduc5+c2liaO/aXU2qW8w1BAQkxmPGD/54Gs/XanRBC23/uXFnZmAFl2vAlR0Q==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@alloc/quick-lru": "^5.0.0",
+        "@csstools/css-parser-algorithms": "^2.0.0",
+        "@csstools/css-tokenizer": "^2.0.0",
+        "@csstools/media-query-list-parser": "^2.0.0",
+        "@ctrl/tinycolor": "^3.0.0",
+        "color-name": "^2.0.0",
+        "css.escape": "^1.0.0",
+        "culori": "^4.0.0",
+        "didyoumean": "^1.0.0",
+        "dlv": "^1.0.0",
+        "line-column": "^1.0.0",
+        "monaco-languageserver-types": "^0.4.0",
+        "monaco-marker-data-provider": "^1.0.0",
+        "monaco-types": "^0.1.0",
+        "monaco-worker-manager": "^2.0.0",
+        "moo": "^0.5.0",
+        "postcss": "^8.0.0",
+        "postcss-js": "^4.0.0",
+        "postcss-nested": "^6.0.0",
+        "postcss-selector-parser": "^6.0.0",
+        "semver": "^7.0.0",
+        "sift-string": "^0.0.2",
+        "stringify-object": "^5.0.0",
+        "tailwindcss": "^3.0.0",
+        "tmp-cache": "^1.0.0",
+        "vscode-languageserver-textdocument": "^1.0.0",
+        "vscode-languageserver-types": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/remcohaszing"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">=0.36"
       }
     },
     "node_modules/monaco-tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaco-tailwind",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Tailwindcss integration for Monaco editor",
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "monaco-tailwindcss",
-  "version": "0.6.1",
+  "name": "wkd/monaco-tailwindcss",
+  "version": "0.0.1",
   "description": "Tailwindcss integration for Monaco editor",
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaco-tailwind",
-  "version": "0.0.13",
+  "version": "0.1.0",
   "description": "Tailwindcss integration for Monaco editor",
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wkd/monaco-tailwindcss",
-  "version": "0.0.1",
+  "name": "monaco-tailwind",
+  "version": "0.0.12",
   "description": "Tailwindcss integration for Monaco editor",
   "files": [
     "index.js",
@@ -23,7 +23,10 @@
     "./tailwindcss.worker": "./tailwindcss.worker.js",
     "./tailwindcss.worker.js": "./tailwindcss.worker.js"
   },
-  "repository": "remcohaszing/monaco-tailwindcss",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/remcohaszing/monaco-tailwindcss.git"
+  },
   "keywords": [
     "monaco",
     "monaco-editor",
@@ -32,15 +35,19 @@
   ],
   "author": "Remco Haszing <remcohaszing@gmail.com>",
   "license": "MIT",
-  "bugs": "https://github.com/remcohaszing/monaco-tailwindcss/issues",
+  "bugs": {
+    "url": "https://github.com/remcohaszing/monaco-tailwindcss/issues"
+  },
   "homepage": "https://monaco-tailwindcss.js.org",
-  "funding": "https://github.com/sponsors/remcohaszing",
+  "funding": {
+    "url": "https://github.com/sponsors/remcohaszing"
+  },
   "dependencies": {
     "@alloc/quick-lru": "^5.0.0",
-    "@ctrl/tinycolor": "^3.0.0",
     "@csstools/css-parser-algorithms": "^2.0.0",
     "@csstools/css-tokenizer": "^2.0.0",
     "@csstools/media-query-list-parser": "^2.0.0",
+    "@ctrl/tinycolor": "^3.0.0",
     "color-name": "^2.0.0",
     "css.escape": "^1.0.0",
     "culori": "^4.0.0",
@@ -49,6 +56,7 @@
     "line-column": "^1.0.0",
     "monaco-languageserver-types": "^0.4.0",
     "monaco-marker-data-provider": "^1.0.0",
+    "monaco-tailwind": "^0.0.1",
     "monaco-types": "^0.1.0",
     "monaco-worker-manager": "^2.0.0",
     "moo": "^0.5.0",
@@ -82,5 +90,10 @@
     "@tailwindcss/language-service": {
       "postcss": "^8.0.0"
     }
-  }
+  },
+  "main": "index.js",
+  "directories": {
+    "example": "examples"
+  },
+  "types": "./index.d.ts"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   createMarkerDataProvider
 } from './languageFeatures.js'
 import { type TailwindcssWorker } from './tailwindcss.worker.js'
+import { PluginAPI } from 'tailwindcss/types/config.js'
 
 export const defaultLanguageSelector = ['css', 'javascript', 'html', 'mdx', 'typescript'] as const
 
@@ -17,10 +18,24 @@ export { tailwindcssData } from './cssData.js'
 
 export const configureMonacoTailwindcss: typeof import('monaco-tailwindcss').configureMonacoTailwindcss =
   (monaco, { languageSelector = defaultLanguageSelector, tailwindConfig } = {}) => {
+    const config = !tailwindConfig
+      ? tailwindConfig
+      : typeof tailwindConfig === 'string'
+        ? tailwindConfig
+        : {
+            ...tailwindConfig,
+            plugins: [
+              ...tailwindConfig.plugins,
+              ({ addUtilities }: PluginAPI) => {
+                addUtilities(tailwindConfig.api.addUtilities || {})
+              }
+            ]
+          }
+
     const workerManager = createWorkerManager<TailwindcssWorker, MonacoTailwindcssOptions>(monaco, {
       label: 'tailwindcss',
       moduleId: 'monaco-tailwindcss/tailwindcss.worker',
-      createData: { tailwindConfig }
+      createData: { tailwindConfig: config }
     })
 
     const disposables = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,25 +17,13 @@ export const defaultLanguageSelector = ['css', 'javascript', 'html', 'mdx', 'typ
 export { tailwindcssData } from './cssData.js'
 
 export const configureMonacoTailwindcss: typeof import('monaco-tailwindcss').configureMonacoTailwindcss =
-  (monaco, { languageSelector = defaultLanguageSelector, tailwindConfig } = {}) => {
-    const config = !tailwindConfig
-      ? tailwindConfig
-      : typeof tailwindConfig === 'string'
-        ? tailwindConfig
-        : {
-            ...tailwindConfig,
-            plugins: [
-              ...tailwindConfig.plugins,
-              ({ addUtilities }: PluginAPI) => {
-                addUtilities(tailwindConfig.api.addUtilities || {})
-              }
-            ]
-          }
-
+  (monaco, options) => {
+    const { languageSelector = defaultLanguageSelector, ...workerData } = options || {}
+    
     const workerManager = createWorkerManager<TailwindcssWorker, MonacoTailwindcssOptions>(monaco, {
       label: 'tailwindcss',
       moduleId: 'monaco-tailwindcss/tailwindcss.worker',
-      createData: { tailwindConfig: config }
+      createData: workerData
     })
 
     const disposables = [

--- a/src/tailwindcss.worker.ts
+++ b/src/tailwindcss.worker.ts
@@ -162,8 +162,6 @@ async function stateFromConfig(
     .filter((className) => className !== '*')
     .map((className) => [className, { color: getColor(state, className) }])
 
-  state.classList.push(['testing', { color: getColor(state, 'testing') }])
-
   return state
 }
 

--- a/tailwindcss.worker.d.ts
+++ b/tailwindcss.worker.d.ts
@@ -10,7 +10,7 @@ export interface TailwindWorkerOptions {
    * @returns
    *   A valid Tailwind configuration.
    */
-  prepareTailwindConfig?: (tailwindConfig?: TailwindConfig | string) => Config | PromiseLike<Config>
+  prepareTailwindConfig?: (tailwindConfig?: TailwindConfig | string) => Config
 }
 
 /**


### PR DESCRIPTION
This PR enhances the capabilities of `configureMonacoTailwindcss`. You can now extend the settings of Intellisense, like adding some `classAttributes` that will trigger `autocompletion`. And most importantly, you have access to Tailwind's built-in Plugin API. Instead of calling them using the `plugins` property of your config, you provide the arguments of each function you wish to call within a `pluginAPI` property.

``` typescript
  configureMonacoTailwindcss(monaco, {
    tailwindConfig,
    intellisense: {tailwindCSS: {classAttributes: ['styles']}},
    pluginAPI: {
      addUtilities: [
        {
          '.button': {
            color: 'var(--black-1)',
            backgroundColor: 'var(--brand-9)',
            padding: '0.5rem 1rem',
            fontSize: '1rem'
          },
          '.button-sm': {
            color: 'var(--black-1)',
            backgroundColor: 'var(--brand-9)',
            padding: '0.25rem 0.5rem',
            fontSize: '0.8rem'
          }
        }
      ]
    }
  })
```

![image](https://github.com/user-attachments/assets/d347457c-64fd-423a-82f0-2833c3ce8f19)
![image](https://github.com/user-attachments/assets/82a6f245-4445-4e1a-b295-d0a9118c4f42)
